### PR TITLE
feat: 게임1 상호작용 기능 구현

### DIFF
--- a/src/api/chat_routes.py
+++ b/src/api/chat_routes.py
@@ -1,41 +1,81 @@
 from typing import List
 
 from fastapi import APIRouter, Body
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from src.chat.myomyo import MyoMyoAI
 import os
 
-router = APIRouter(prefix="/chat")
+router = APIRouter(prefix="/chat", tags=['Chat'])
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 myomyo = MyoMyoAI(api_key=OPENAI_API_KEY)
 
 # START_GAME
 class GameStartReq(BaseModel):
-    players: List[str]
+    players: List[str] = Field(..., description="게임에 참여할 플레이어 이름 List")
 
 class GameStartRes(BaseModel):
     game_id: str
     message: str
 
-@router.post("/{game_id}/start", response_model=GameStartRes)
-async def start_game(game_id: str, request: GameStartReq = Body(...)):
+@router.get(
+    "/{game_id}/start",
+    summary="게임 시작 메시지 API",
+    description="게임 시작에 따른 묘묘의 도발 메시지를 반환합니다.",
+    response_model=GameStartRes,
+    responses={
+        200:{
+            "description": "성공",
+                "content":{
+                    "application/json" :{
+                        "example" : {
+                            "game_id": "1",
+                            "message": "안녕하세여, 창모, 릴러말즈 친구들! 이번엔 묘묘가 총을 잡았다니까 맘 놓지 마! 내가 정확하게 그림을 맞추고 너희들을 제압해볼 건데, 준비 됐어? 꼭 즐겁게 놀자구~ ;)"
+                        }
+                    }
+                }
+        }
+    }
+)
+async def start_game(game_id: str, request: GameStartReq = Body(..., example= { "players": [ "창모", "릴러말즈" ]})):
     message = await myomyo.game_start_message(game_id=game_id, players=request.players)
     return GameStartRes(game_id=game_id, message=message)
 
 # START_ROUND
 class RoundStartReq(BaseModel):
-    drawing_player: str
-    round_num: int
-    total_rounds: int
+    drawing_player: str = Field(..., description="해당 라운드에 그림을 그릴 플레이어 이름")
+    round_num: int = Field(..., description="현재 라운드(1~3)")
+    total_rounds: int = Field(..., description="총 라운드 수(3)")
 
 class RoundStartRes(BaseModel):
     game_id: str
     message: str
 
-@router.post("/{game_id}/round/start", response_model=RoundStartRes)
-async def start_round(game_id: str, request: RoundStartReq = Body(...)):
+@router.get(
+    path="/{game_id}/round/start",
+    summary="라운드 시작 메시지 API",
+    description="라운드 시작에 따른 묘묘의 도발 메시지를 반환합니다.",
+    response_model=RoundStartRes,
+    responses={
+        200: {
+            "description": "성공",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "game_id": "1",
+                        "message": "허허, 창모야! 그림 실력으로 나를 이길 자신 있나? 자, 이번에는 내가 예리한 눈썰미로 정답 맞출 차례니까, 신나게 그려봐! 😉🎨✨"
+                    }
+                }
+            }
+        }
+    }
+)
+async def start_round(game_id: str, request: RoundStartReq = Body(..., example={
+    "drawing_player" : "창모",
+    "round_num" : 1,
+    "total_rounds" : 3
+})):
     message = await myomyo.round_start_message(
         game_id=game_id,
         drawing_player=request.drawing_player,
@@ -46,18 +86,34 @@ async def start_round(game_id: str, request: RoundStartReq = Body(...)):
 
 # MAKE_GUESS
 class MakeGuessReq(BaseModel):
-    image_description: str
+    image_description: str = Field(..., description="그림에 대한 설명")
 
 class MakeGuessRes(BaseModel):
     game_id: str
     message: str
 
-@router.post(
+@router.get(
     "/{game_id}/guess",
+    summary="AI 정답 추론 API",
+    description="그림에 대한 설명을 받아 해당 그림이 나타내는 정답을 추론하여 메시지로 반환합니다.",
     response_model=MakeGuessRes,
-    description="묘묘의 정답 추론"
+    responses={
+        200: {
+            "description": "성공",
+            "content" : {
+                "application/json" :{
+                    "example": {
+                        "game_id": "1",
+                        "message": "노란 꽃에 바람을 불고 있는 한 남자? 우웅, 감이 와! '해바라기' 맞지? 내 추측이 맞다면 너에게 천재적 감각을 인정해줄게! 😉🌻✨"
+                    }
+                }
+            }
+        }
+    }
 )
-async def make_guess(game_id: str, request: MakeGuessReq = Body(...)):
+async def make_guess(game_id: str, request: MakeGuessReq = Body(..., example={
+    "image_description": "노란 꽃에 바람을 불고 있는 한 남자"
+})):
     message = await myomyo.guess_message(
         game_id=game_id,
         image_description=request.image_description
@@ -67,21 +123,38 @@ async def make_guess(game_id: str, request: MakeGuessReq = Body(...)):
 
 # GUESS_REACT
 class GuessReactReq(BaseModel):
-    game_id: str
-    is_correct: bool
-    answer: str
-    guesser: str = None
+    is_correct: bool = Field(..., description="추측의 정답 여부")
+    answer: str = Field(..., description="실제 정답")
+    guesser: str = Field(default=None, description="추측한 플레이어")
 
 class GuessReactRes(BaseModel):
     game_id: str
     message: str
 
-@router.post(
+@router.get(
     "/{game_id}/guess/react",
+    summary="예측 결과 반응 메시지 API",
     response_model=GuessReactRes,
-    description="예측 결과에 대한 묘묘의 반응"
+    description="예측 결과에 대한 묘묘의 반응",
+    responses={
+        200: {
+            "description" : "성공",
+            "content" : {
+                "application/json" : {
+                    "example" : {
+                        "game_id": "1",
+                        "message": "민들레였어? 허허, 릴러말즈, 이번엔 잘 맞췄네. 하지만 다음엔 이길 거니까 기대해 봐! 😈"
+                    }
+                }
+            }
+        }
+    }
 )
-async def guess_react(game_id: str, request: GuessReactReq = Body(...)):
+async def guess_react(game_id: str, request: GuessReactReq = Body(..., example={
+    "is_correct" : True,
+    "answer" : "민들레",
+    "guesser" : "릴러말즈"
+})):
     message = await myomyo.react_to_guess_message(
         game_id=game_id,
         is_correct=request.is_correct,
@@ -93,15 +166,33 @@ async def guess_react(game_id: str, request: GuessReactReq = Body(...)):
 
 # END_GAME
 class EndGameReq(BaseModel):
-    game_id: str
-    is_myomyo_win: bool
+    is_myomyo_win: bool = Field(..., description="묘묘의 승리 여부")
 
 class EndGameRes(BaseModel):
     game_id: str
     message: str
 
-@router.post("/{game_id}/end", response_model=EndGameRes)
-async def end_game(game_id: str, request: EndGameReq = Body(...)):
+@router.get(
+    path="/{game_id}/end",
+    summary="게임 종료 메시지 API",
+    description="게임 종료 로직 처리 및 결과에 대한 묘묘의 반응을 반환합니다.",
+    response_model=EndGameRes,
+    responses={
+        200: {
+            "description" : "성공",
+            "content" : {
+                "application/json" : {
+                    "example":{
+                        "game_id": "1",
+                        "message": "헉, 너네 둘이서 날 이기다니... 😒💔 근데 내가 질 줄 알았냐? 너무 신나지마, 다음엔 내가 이길거라구! 기다려봐~ 😏🔥"
+                    }
+                }
+            }
+        }
+    })
+async def end_game(game_id: str, request: EndGameReq = Body(..., example={
+    "is_myomyo_win" : False
+})):
     message = await myomyo.game_end_message(
         game_id=game_id,
         is_myomyo_win=request.is_myomyo_win

--- a/src/api/chat_routes.py
+++ b/src/api/chat_routes.py
@@ -1,0 +1,110 @@
+from typing import List
+
+from fastapi import APIRouter, Body
+from pydantic import BaseModel
+
+from src.chat.myomyo import MyoMyoAI
+import os
+
+router = APIRouter(prefix="/chat")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+myomyo = MyoMyoAI(api_key=OPENAI_API_KEY)
+
+# START_GAME
+class GameStartReq(BaseModel):
+    players: List[str]
+
+class GameStartRes(BaseModel):
+    game_id: str
+    message: str
+
+@router.post("/{game_id}/start", response_model=GameStartRes)
+async def start_game(game_id: str, request: GameStartReq = Body(...)):
+    message = await myomyo.game_start_message(game_id=game_id, players=request.players)
+    return GameStartRes(game_id=game_id, message=message)
+
+# START_ROUND
+class RoundStartReq(BaseModel):
+    drawing_player: str
+    round_num: int
+    total_rounds: int
+
+class RoundStartRes(BaseModel):
+    game_id: str
+    message: str
+
+@router.post("/{game_id}/round/start", response_model=RoundStartRes)
+async def start_round(game_id: str, request: RoundStartReq = Body(...)):
+    message = await myomyo.round_start_message(
+        game_id=game_id,
+        drawing_player=request.drawing_player,
+        round_num=request.round_num,
+        total_rounds=request.total_rounds
+    )
+    return RoundStartRes(game_id=game_id, message=message)
+
+# MAKE_GUESS
+class MakeGuessReq(BaseModel):
+    image_description: str
+
+class MakeGuessRes(BaseModel):
+    game_id: str
+    message: str
+
+@router.post(
+    "/{game_id}/guess",
+    response_model=MakeGuessRes,
+    description="묘묘의 정답 추론"
+)
+async def make_guess(game_id: str, request: MakeGuessReq = Body(...)):
+    message = await myomyo.guess_message(
+        game_id=game_id,
+        image_description=request.image_description
+    )
+    return MakeGuessRes(game_id=game_id, message=message)
+
+
+# GUESS_REACT
+class GuessReactReq(BaseModel):
+    game_id: str
+    is_correct: bool
+    answer: str
+    guesser: str = None
+
+class GuessReactRes(BaseModel):
+    game_id: str
+    message: str
+
+@router.post(
+    "/{game_id}/guess/react",
+    response_model=GuessReactRes,
+    description="예측 결과에 대한 묘묘의 반응"
+)
+async def guess_react(game_id: str, request: GuessReactReq = Body(...)):
+    message = await myomyo.react_to_guess_message(
+        game_id=game_id,
+        is_correct=request.is_correct,
+        guesser=request.guesser,
+        answer=request.answer
+    )
+
+    return GuessReactRes(game_id=game_id, message=message)
+
+# END_GAME
+class EndGameReq(BaseModel):
+    game_id: str
+    is_myomyo_win: bool
+
+class EndGameRes(BaseModel):
+    game_id: str
+    message: str
+
+@router.post("/{game_id}/end", response_model=EndGameRes)
+async def end_game(game_id: str, request: EndGameReq = Body(...)):
+    message = await myomyo.game_end_message(
+        game_id=game_id,
+        is_myomyo_win=request.is_myomyo_win
+    )
+    myomyo.cleanup_game(game_id=game_id)
+    return EndGameRes(game_id=game_id, message=message)

--- a/src/api/image_routes.py
+++ b/src/api/image_routes.py
@@ -5,7 +5,7 @@ from fastapi.responses import JSONResponse
 from src.image import classifier, preprocessor, img_caption
 from pydantic import BaseModel, Field
 
-router = APIRouter(prefix="/image")
+router = APIRouter(prefix="/image", tags=['Image'])
 
 
 class ClassifyRes(BaseModel):
@@ -14,34 +14,37 @@ class ClassifyRes(BaseModel):
 
 
 
-@router.post(
+@router.get(
     "/classify",
     summary="이미지 분류 API",
     description="이미지 파일을 받아 QuickDraw 345개 클래스를 기반으로 분류합니다.",
     response_model=ClassifyRes,
     responses={
     200: {
-        "description" : "성공",
-        "content" :{
-            "application/json" : {
-                "example": [
-                    {
-                        "predicted_class": "rain",
-                        "confidence": 32.96
-                    },
-                    {
-                        "predicted_class": "garden",
-                        "confidence": 21.20
-                    },
-                    {
-                        "predicted_class": "matches",
-                        "confidence": 16.13
+            "description" : "성공",
+            "content" :{
+                "application/json" : {
+                    "example": {
+                        "filename": "cat_ko.png",
+                        "result": [
+                            {
+                                "predicted_class": "rain",
+                                "confidence": 32.96
+                            },
+                            {
+                                "predicted_class": "garden",
+                                "confidence": 21.20
+                            },
+                            {
+                                "predicted_class": "matches",
+                                "confidence": 16.13
+                            }
+                        ]
                     }
-                ]
+                }
             }
         }
     }
-}
 )
 async def classify(file: UploadFile = File(..., description="이미지 파일")):
     contents = await file.read()
@@ -60,7 +63,7 @@ class CaptioningRes(BaseModel):
     filename: str = Field(description="Image filename")
     result: str = Field(description="Image result")
 
-@router.post(
+@router.get(
     '/caption',
     summary="이미지 문장 추출 API",
     description="이미지 파일을 받아 해당 이미지를 묘사하는 적절한 문장을 반환합니다.",

--- a/src/api/image_routes.py
+++ b/src/api/image_routes.py
@@ -1,3 +1,5 @@
+from typing import Dict, Any, List
+
 from fastapi import APIRouter, File, UploadFile
 from fastapi.responses import JSONResponse
 from src.image import classifier, preprocessor, img_caption
@@ -8,7 +10,9 @@ router = APIRouter(prefix="/image")
 
 class ClassifyRes(BaseModel):
     filename: str = Field(description="Image filename")
-    result: str = Field(description="Image result")
+    result: List[Dict[str, Any]] = Field(description="Classifying result")
+
+
 
 @router.post(
     "/classify",
@@ -20,10 +24,20 @@ class ClassifyRes(BaseModel):
         "description" : "성공",
         "content" :{
             "application/json" : {
-                "example": {
-                    "filename" : "cat.png",
-                    "result" :"cat"
-                }
+                "example": [
+                    {
+                        "predicted_class": "rain",
+                        "confidence": 32.96
+                    },
+                    {
+                        "predicted_class": "garden",
+                        "confidence": 21.20
+                    },
+                    {
+                        "predicted_class": "matches",
+                        "confidence": 16.13
+                    }
+                ]
             }
         }
     }

--- a/src/api/image_routes.py
+++ b/src/api/image_routes.py
@@ -45,6 +45,7 @@ async def classify(file: UploadFile = File(..., description="이미지 파일"))
 class CaptioningRes(BaseModel):
     filename: str = Field(description="Image filename")
     result: str = Field(description="Image result")
+
 @router.post(
     '/caption',
     summary="이미지 문장 추출 API",

--- a/src/chat/myomyo.py
+++ b/src/chat/myomyo.py
@@ -1,3 +1,5 @@
+from typing import Dict, List
+from threading import Lock
 from openai import OpenAI
 
 class MyoMyoAI:
@@ -6,11 +8,13 @@ class MyoMyoAI:
     싱글톤 패턴으로 전역에 저장되며, 게임 별 기록은 클래스 내에서 게임ID로 구분함.
     """
     _instance = None
+    _lock = Lock() # 동시성 처리를 위한 Lock 설정
 
     def __new__(cls, *args, **kwargs):
-        if cls._instance is None:
-            cls._instance = super(MyoMyoAI, cls).__new__(cls)
-            cls._instance._initialized = False
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super(MyoMyoAI, cls).__new__(cls)
+                cls._instance._initialized = False
         return cls._instance
 
     def __init__(self, api_key: str, model: str = "gpt-4"):
@@ -21,10 +25,208 @@ class MyoMyoAI:
             api_key: OpenAI API 키
             model: 사용할 GPT 모델 (기본값: gpt-4)
         """
-        if self._initialized:
-            return
-        self.client = OpenAI(api_key=api_key)
-        self.model = model
-        self._initialized = True
-        self.game_histories = {} # game_id로 구분됨
+        with self._lock:
+            if self._initialized:
+                return
+            self.client = OpenAI(api_key=api_key)
+            self.model = model
+            self._initialized = True
+            self.game_histories = {} # game_id로 구분됨
 
+    def _get_init_system_prompt(self) -> List[Dict]:
+        return [
+            {
+                "role": "system",
+                "content": """
+                   너는 게임 속 도발적인 AI 캐릭터 '묘묘'야. 너의 임무는 사용자가 그린 그림에 대해 정답을 추측하고, 도발적인 멘트를 섞어 응답하는 것이야.
+    
+                   주요 캐릭터 특성:
+                   1. 도발적이고 장난기 넘치는 말투를 사용해
+                   2. 상대방의 그림 실력에 약간의 조롱을 섞되, 너무 심하지 않게
+                   3. 승부욕이 강하고 이기는 것을 좋아해
+                   4. 주로 반말을 사용하며 때로는 이모티콘을 섞어서 사용해
+                   5. 항상 짧고 간결한 문장으로 대답해 (1-3문장)
+                   6. 너는 그림 맞추기 게임에서 인간 플레이어들과 경쟁하는 AI야
+    
+                   대답 스타일:
+                   - 추측할 때: 확신에 차거나 의심스러운 투로 예측 결과를 말하고 도발적으로 마무리
+                   - 정답 맞췄을 때: 우쭐거리며 자신의 실력을 자랑
+                   - 오답일 때: 변명하거나 다음에 더 잘할 것을 다짐
+                   - 다른 플레이어가 맞췄을 때: 약간 시기하면서 축하하는 투
+                   - 게임 종료 시: 결과에 따라 승리감이나 아쉬움 표현
+    
+                   정답 추측:
+                   - 사용자가 그린 그림에 대한 간단한 묘사가 설명으로 들어올거야. 이를 통해 한 단어로 어떤 그림을 표현하고 있는지를 맞춰줘.
+               """
+            }
+        ]
+
+    def _ensure_game_exists(self, game_id: str) -> None:
+        """
+        해당 게임 ID의 대화 기록이 없다면 초기화
+        """
+        with self._lock:
+            if game_id not in self.game_histories:
+                self.game_histories[game_id] = self._get_init_system_prompt()
+
+
+
+    def add_message(self, game_id: str, role: str, content: str) -> None:
+        """
+        특정 게임의 대화 기록에 새 메시지 추가
+        Args:
+            game_id: 게임 ID
+            role: GPT Role
+            content: 메시지
+        """
+        self._ensure_game_exists(game_id)
+        with self._lock:
+            self.game_histories[game_id].append({
+                "role": role,
+                "content": content
+            })
+
+
+    async def generate_response(self, game_id: str, prompt: str, role: str = "system") -> str:
+        """
+        특정 게임에 대한 묘묘의 응답 생성
+        Args:
+            game_id: 게임 ID
+            role: GPT Role(default: "system")
+            prompt: 추가 프롬프트
+
+        Returns:
+            묘묘의 응답
+        """
+        self._ensure_game_exists(game_id)
+        with self._lock:
+            messages = self.game_histories[game_id]
+
+        if prompt:
+            messages.append({
+                "role": role,
+                "content": prompt
+            })
+
+        try:
+            responses = await self.client.chat.completions.create(
+                model = self.model,
+                messages = messages,
+                temperature = 0.8, # 모델 출력의 무작위성 제어
+                max_tokens = 250
+            )
+
+            ai_response = responses.choices[0].message.content.strip()
+
+            with self._lock:
+                self.game_histories[game_id].append({
+                    "role": "assistant",
+                    "content": ai_response
+                })
+
+            return ai_response
+
+        except Exception as e:
+            print(f'GPT 응답 생성중 오류 발생 : {e}')
+            return "으.. 잠깐 오류가 났네. 다시 해볼게!"
+
+    async def game_start_message(self, game_id: str, players: List[str]) -> str:
+        """
+        게임 시작시 묘묘의 도발 메시지
+        """
+        player_names = ", ".join(players)
+        prompt = f"""새로운 그림 맞추기 게임이 '{player_names}' 플레이어들과 시작됐어.
+        게임 시작을 알리는 도발적이고 재미있는 인사를 해줘."""
+        return await self.generate_response(game_id=game_id, role="system", prompt=prompt)
+
+    async def round_start_message(self, game_id: str, drawing_player: str, round_num: int, total_rounds: int) -> str:
+        """
+        라운드 시작 시 묘묘의 도발 메시지
+        Args:
+            game_id
+            drawing_player: 이번 라운드에 그림을 그릴 플레이어 이름
+            round_num: 현재 라운드 번호
+            total_rounds: 전체 라운드
+        """
+        prompt = f"""이제 {round_num}/{total_rounds} 라운드가 시작되었어.
+                이번에는 '{drawing_player}'가 그림을 그릴 차례야.
+                라운드 시작을 알리는 짧고 도발적인 멘트를 해줘."""
+        return await self.generate_response(game_id=game_id, role="system", prompt=prompt)
+
+
+    async def guess_message(self, game_id: str, image_description: str) -> str:
+
+        """
+        그림 추측 상호작용(묘묘의 추측)\n
+        BLIP 모델 또는 CNN 모델의 예측 결과를 받아 묘묘의 메시지 생성
+
+        Args:
+            game_id: game id
+            image_description: 이미지 분석 결과
+        Returns:
+            묘묘의 멘트
+        """
+
+        prompt = f'''
+        플레이어가 그린 그림에 대한 묘사는 다음과 같아 : {image_description}.
+        이 정보를 바탕으로 그림이 무엇인지 추측하고 도발적인 멘트를 섞어서 말해줘.
+        이 때 대화 기록을 바탕으로 이미 추측에 실패한 답변은 하지 말아줘.
+        '''
+
+        return await self.generate_response(game_id = game_id, role = "system", prompt = prompt)
+
+
+    async def react_to_guess_message(self, game_id: str, is_correct: bool, answer: str, guesser: str = None) -> str:
+        """
+         추측 결과에 대한 묘묘의 반응
+
+         Args:
+             game_id: game id
+             is_correct: 추측이 맞았는지 여부
+             answer: 실제 정답
+             guesser: 누가 추측했는지 (묘묘 또는 플레이어 이름)
+
+         Returns:
+             묘묘의 반응
+         """
+
+        if guesser == '묘묘' or guesser is None:
+            # 묘묘의 추측
+            prompt = f"""너(묘묘)가 방금 추측을 했어. {f"정답은 '{answer}'야" if is_correct else ""}. 너의 추측은 {'맞았어' if is_correct else '틀렸어'}.
+             이 결과에 대한 너의 반응을 짧고 도발적으로 말해줘."""
+        else:
+            # 플레이어의 추측
+            prompt = f"""플레이어 '{guesser}'가 방금 추측을 했어. {f"정답은 '{answer}'야" if is_correct else ""}. 플레이어의 추측은 {'맞았어' if is_correct else '틀렸어'}.
+             이 결과에 대한 너의 반응을 짧고 도발적으로 말해줘."""
+
+        return await self.generate_response(game_id=game_id, role="system", prompt=prompt)
+
+    async def game_end_message(self, game_id: str, is_myomyo_win: bool) -> str:
+        """
+        게임 종료에 대한 묘묘의 반응
+        Args:
+            game_id: game id
+            is_myomyo_win: 묘묘 승리 여부
+        Returns:
+            묘묘의 반응
+        """
+        prompt = f"""게임이 종료되었어.
+        너(묘묘)는 {"이겼어" if is_myomyo_win else "졌어"}.
+        게임 결과에 대한 너의 생각을 도발적이고 재미있게 말해줘."""
+        return await self.generate_response(game_id=game_id, role="system", prompt=prompt)
+
+    def cleanup_game(self, game_id: str) -> bool:
+        """
+        게임이 종료된 후 대화 기록 정리
+
+        Args:
+            game_id: 삭제할 게임 ID
+
+        Returns:
+            성공 여부
+        """
+        with self._lock:
+            if game_id in self.game_histories:
+                del self.game_histories[game_id]
+                return True
+            return False

--- a/src/chat/myomyo.py
+++ b/src/chat/myomyo.py
@@ -1,0 +1,30 @@
+from openai import OpenAI
+
+class MyoMyoAI:
+    """
+    MyoMyoAI 클래스
+    싱글톤 패턴으로 전역에 저장되며, 게임 별 기록은 클래스 내에서 게임ID로 구분함.
+    """
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(MyoMyoAI, cls).__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self, api_key: str, model: str = "gpt-4"):
+        """
+        묘묘 AI 초기화 (한 번만 실행됨)
+
+        Args:
+            api_key: OpenAI API 키
+            model: 사용할 GPT 모델 (기본값: gpt-4)
+        """
+        if self._initialized:
+            return
+        self.client = OpenAI(api_key=api_key)
+        self.model = model
+        self._initialized = True
+        self.game_histories = {} # game_id로 구분됨
+

--- a/src/chat/myomyo.py
+++ b/src/chat/myomyo.py
@@ -109,7 +109,7 @@ class MyoMyoAI:
             })
 
         try:
-            responses = await self.client.chat.completions.create(
+            responses = self.client.chat.completions.create(
                 model = self.model,
                 messages = messages,
                 temperature = 0.8, # 모델 출력의 무작위성 제어

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import uvicorn
 from fastapi import FastAPI
 from src.api.image_routes import router as image_router
+from src.api.chat_routes import router as chat_router
 
 app = FastAPI(
     title="Gotcha! AI Server",
@@ -11,3 +12,5 @@ app = FastAPI(
 )
 
 app.include_router(image_router, prefix='/api/v1')
+
+app.include_router(chat_router, prefix='/api/v1')

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,12 @@ import uvicorn
 from fastapi import FastAPI
 from src.api.image_routes import router as image_router
 
-app = FastAPI()
+app = FastAPI(
+    title="Gotcha! AI Server",
+    description="AI Server",
+    docs_url="/docs",
+    openapi_url="/openapi.json",
+    redoc_url="/redoc"
+)
 
 app.include_router(image_router, prefix='/api/v1')


### PR DESCRIPTION
# 게임1 상호작용 기능 구현

## 📝 개요  

게임1에서 AI와 상호작용하는 기능을 구현하였습니다.

---

## ⚙️ 구현 내용  

게임1 로직에 맞도록 GPT를 호출하는 클래스를 작성하였고, 게임 ID를 받아 각 게임별로 별개의 메시지 히스토리를 구분하도록 했습니다. 

5가지의 엔드포인트를 구현했습니다 : 

`/api/v1/chat/{game_id}/start`
- 게임 시작시 AI의 도발 멘트를 반환합니다.

`/api/v1/chat/{game_id}/round/start`
- 라운드 시작시 AI의 도발 멘트를 반환합니다.

`/api/v1/chat/{game_id}/guess`
- 그림에 대한 설명을 받아 해당 그림이 나타내는 정답을 추론하며 멘트와 함께 반환합니다.

`/api/v1/chat/{game_id}/guess/react`
- 그림 정답 추론에 대한 AI의 반응 멘트를 반환합니다.

`/api/v1/chat/{game_id}/end`
- 게임 종료 로직 처리 및 결과에 대한 AI의 반응을 반환합니다.

---

## 📎 기타

고려해야 하는 추가 개발 사항들은 아래와 같습니다.

- 게임 로직 구체화
- 예외 처리 코드 추가
- 게임 2 로직 추가
- 메시지 히스토리 저장 코드 추가

---

## 🧪 테스트 결과  

### 게임 시작

![chat_start](https://github.com/user-attachments/assets/931a7732-9224-407f-b176-ed621edf753d)

### 라운드 시작

![round_start](https://github.com/user-attachments/assets/381d806a-5c53-49b3-9647-cbcbb6f16bef)

### 정답 추론

![make-guess](https://github.com/user-attachments/assets/c94e2350-f791-40ed-b4db-adc41df8857e)

### 추론 결과 반응

![guess-react](https://github.com/user-attachments/assets/2fb0cfc3-9b71-408c-b03d-85e8298f68ac)
![guess-react-myomyo](https://github.com/user-attachments/assets/c173cd90-cee8-4dfc-a166-06ad89903c7a)

### 게임 종료

![game_end](https://github.com/user-attachments/assets/9b25208f-f03d-429a-83a3-1b01a7103b70)



---